### PR TITLE
Add ArquillianEnricher JUnit Rule

### DIFF
--- a/thucydides-tests/src/test/java/org/arquillian/example/functional/SearchingBeersStory.java
+++ b/thucydides-tests/src/test/java/org/arquillian/example/functional/SearchingBeersStory.java
@@ -14,10 +14,12 @@ import org.arquillian.example.functional.pages.Beer;
 import org.arquillian.example.functional.specs.BeerAdvisor;
 import org.arquillian.example.functional.steps.SearchingSteps;
 import org.arquillian.example.functional.utils.Deployments;
+import org.arquillian.example.thucydides.ArquillianEnricher;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
@@ -36,6 +38,9 @@ public class SearchingBeersStory
    @Steps
    public SearchingSteps searchingSteps;
 
+   @Rule
+   public ArquillianEnricher enricher = new ArquillianEnricher();
+
    @Deployment(testable = false)
    public static WebArchive createTestArchive()
    {
@@ -43,12 +48,12 @@ public class SearchingBeersStory
    }
 
    @ArquillianResource
-   URL deploymentUrl; // Currently results with NPE - enricher is apparently not kicked in
+   URL deploymentUrl;
 
    @Before
    public void before_tests()
    {
-      pages.setDefaultBaseUrl("http://localhost:8080/beer-advisor");
+      pages.setDefaultBaseUrl(deploymentUrl.toExternalForm());
    }
 
    @Test

--- a/thucydides-tests/src/test/java/org/arquillian/example/thucydides/ArquillianEnricher.java
+++ b/thucydides-tests/src/test/java/org/arquillian/example/thucydides/ArquillianEnricher.java
@@ -1,0 +1,29 @@
+package org.arquillian.example.thucydides;
+
+import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+public class ArquillianEnricher implements MethodRule
+{
+
+   @Override
+   public Statement apply(final Statement base, final FrameworkMethod method, final Object target)
+   {
+      return new Statement() {
+         public void evaluate() throws Throwable {
+            
+            TestRunnerAdaptor adaptor = ArquillianListener.adaptor.get();
+            adaptor.before(target, method.getMethod(), LifecycleMethodExecutor.NO_OP);
+            try {
+               base.evaluate();
+            } finally {
+               adaptor.after(target, method.getMethod(), LifecycleMethodExecutor.NO_OP);
+            }
+         };
+      };
+   }
+
+}

--- a/thucydides-tests/src/test/java/org/arquillian/example/thucydides/ArquillianListener.java
+++ b/thucydides-tests/src/test/java/org/arquillian/example/thucydides/ArquillianListener.java
@@ -30,7 +30,7 @@ public class ArquillianListener implements StepListener
     * and the currentClass instance, i.e. the Test class. This also means that the archive is not undeployed by Arquillian.
     *
     */
-   private static final ThreadLocal<TestRunnerAdaptor> adaptor = new ThreadLocal<TestRunnerAdaptor>();
+   static final ThreadLocal<TestRunnerAdaptor> adaptor = new ThreadLocal<TestRunnerAdaptor>();
 
    private static final ThreadLocal<Class<?>> currentClass = new ThreadLocal<Class<?>>();
 


### PR DESCRIPTION
Thucydides does not expose TestInstance in it's StepListener
so we need a JUnit Rule to access the instance and trigger Before/After
events for Arquillian Enrichment support.
